### PR TITLE
Use the longest key as the 'best' match

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.vscode-test
+package-lock.json

--- a/src/getSuffixForFilename.js
+++ b/src/getSuffixForFilename.js
@@ -1,17 +1,22 @@
-const isSuffixMatch = (suffix, str) => new RegExp(`${suffix}$`).test(str)
+const isSuffixMatch = str => suffix => new RegExp(`${suffix}$`).test(str)
+const byLengthDescending = (first, second) => second.length - first.length;
 
 const NO_MATCH = {
     toSuffix: null
 }
 
 module.exports = (map, fileName) => {
-    for (const fromSuffix in map) {
+    const keys = Object.keys(map);
 
-        if (isSuffixMatch(fromSuffix, fileName)) {
-            return {
-                fromSuffix,
-                toSuffix: map[fromSuffix]
-            }
+    const match = keys
+    .filter(isSuffixMatch(fileName))
+    .sort(byLengthDescending)
+    .shift();
+
+    if(match){
+        return {
+            fromSuffix: match,
+            toSuffix: map[match]
         }
     }
 

--- a/test/getSuffixForFilename.test.js
+++ b/test/getSuffixForFilename.test.js
@@ -25,4 +25,17 @@ suite('Get Suffix For Document', function() {
 
         assert.deepEqual(getSuffixForFilename(map, filename), {fromSuffix: '.foo', toSuffix: '.bar'})
     });
+
+    suite('The file name matches multiple keys', () => {
+        test('returns the map that more closely matches', () => {
+            const filename = 'a.spec.js';
+
+            const map = {
+                '.js': '.spec.js',
+                '.spec.js': '.js'
+            };
+
+            assert.deepEqual(getSuffixForFilename(map, filename), {fromSuffix: '.spec.js', toSuffix: '.js'});
+        });
+    });
 });


### PR DESCRIPTION
For issue #9, the problem as it exists today is that the search stopped at soon as it found a single match. A file `myFile.spec.js` matches **both** `.js` and `.spec.js`, but `.js` appears first in the map, so it would stop after that result. And since `myFile.spec.spec.js` didn't exist, it would create a new one.

This will now get **all** the matches, it will then sort them by length descending. This assumes that the longer the key (`.spec.js` vs `.js` in this key) will be the better match. I _think_ this is a valid assumption.  

As a result, after this PR you have a couple situations:

1. User is on `myFile.js` and runs the extension: `myFile.spec.js` will be loaded
2. User is on `myFile.spec.js` and runs the extension: `myFile.js` will be loaded.